### PR TITLE
Make page fully HTTPS secure

### DIFF
--- a/demo/components/header.js
+++ b/demo/components/header.js
@@ -71,7 +71,7 @@ export default class Header extends Component {
                         <div className="product-hunt-featured">
                             <h3 class="animated fadeInUp">Featured on</h3>
                             <span className="hint--bottom hint--bounce hint--rounded" data-hint="Product Hunt">
-                                <img class="animated fadeInUp" src="http://i.imgur.com/BPK4eNA.png"/>
+                                <img class="animated fadeInUp" src="https://i.imgur.com/BPK4eNA.png"/>
                             </span>
                         </div>
                     </a>


### PR DESCRIPTION
The Product Hunt logo was aquired from the HTTP version of imgur, not HTTPS, making the website insecure by serving mixed content.

Chrome warning:
> Mixed Content: The page at 'https://bttn.surge.sh/' was loaded over HTTPS, but requested an insecure image 'http://i.imgur.com/BPK4eNA.png'. This content should also be served over HTTPS.